### PR TITLE
Add `main` property to allow short require

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-filesize-filter",
   "version": "0.1.1",
   "description": "Format byte counts as file size strings with the appropriate unit",
+  "main": "angular-filesize-filter.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JangoBrick/angular-filesize-filter.git"


### PR DESCRIPTION
That allow 
`require('angular-filesize-filter');`
instad of 
`require('angular-filesize-filter/angular-filesize-filter');`